### PR TITLE
Fixed possible ReferenceError in ArtJs.log

### DIFF
--- a/com/arthwood/utils/Log.js
+++ b/com/arthwood/utils/Log.js
@@ -1,5 +1,5 @@
 ArtJs.log = function() {
-  if (console) {
+  if (typeof console === "object") {
     console.log(ArtJs.$A(arguments));
   }
 };


### PR DESCRIPTION
Checking `if (console)` will result in ReferenceError in environments (browsers) that don't have built-in console object. So it should be either `if (window.console)` which works for browsers or `if (typeof console !== "undefined")` or even `if (typeof console === "object")`.
